### PR TITLE
fix CI dependency error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Dependencies
       run: |
           sudo apt-get -q update
-          sudo -E apt-get -yq --no-install-suggests --no-install-recommends install python-minimal
+          sudo -E apt-get -yq --no-install-suggests --no-install-recommends install python2-minimal
           cd /tmp && go get -u github.com/vbatts/git-validation
 
     - name: Build


### PR DESCRIPTION
Fix the failure reported by git action

Package python-minimal is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  python2-minimal

E: Package 'python-minimal' has no installation candidate

Signed-off-by: Wang Yan <wangyan@vmware.com>